### PR TITLE
Use 'uniqid' instead of 'rand' to avoid collisions

### DIFF
--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -8,7 +8,7 @@ use Faker\Generator as Faker;
 
 $factory->define(Product::class, function (Faker $faker) {
     return [
-        'code' => "CODE" . rand(10000,99999),
+        'code' => uniqid("CODE"),
         'name' => $faker->word(2),
         'description' => $faker->paragraph(2),
         'price' => $faker->numberBetween(50, 50000 ), // Integer cents


### PR DESCRIPTION
Dans la classe `ProductFactory`, un code "unique" est créé pour un produit de la façon suivante. 

https://github.com/ClubCedille/crabe-inventaire/blob/b147e65d9dbbc45243ffcf367014bd1b354b4921/database/factories/ProductFactory.php#L11

Il y a une règle dans la base de donnée qui contraint le code à être unique. 

https://github.com/ClubCedille/crabe-inventaire/blob/b147e65d9dbbc45243ffcf367014bd1b354b4921/database/migrations/2019_07_16_142826_create_products_table.php#L18

Cependant, il est possible que la fonction `rand` utilisée retourne deux fois le même résultat. Lors du dernier commit, il semble que les tests aient échoués pour cette raison. 

https://circleci.com/gh/ClubCedille/crabe-inventaire/35?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
![image](https://user-images.githubusercontent.com/6194072/66501461-74aa8300-ea91-11e9-840e-7dafe1baaa89.png)

Ce PR modifie la génération d'un code unique pour utiliser la fonction `uniqid` de PHP. Elle ne garantie pas l'unicité à 100%, cependant la valeur retournée est basée sur la date et l'heure de l'ordinateur en microsecondes. Plusieurs identifiants peuvent être générés séquentiellement et ils seront différents. 

Cela corrige le problème pour le moment. La meilleure solution serait de générer un checksum cryptographiquement sécuritaire basé sur les autres valeurs de l'objet, mais cela compliquerait beaucoup le code pour le moment. 
